### PR TITLE
Removed git_repository_guide_context from repo

### DIFF
--- a/apb/playbooks/provision.yml
+++ b/apb/playbooks/provision.yml
@@ -12,7 +12,6 @@
     git_repository_lab_reference: ocp-3.11
     git_repository_guide_path: tosin2013/cloud-native-guides
     git_repository_guide_reference: ocp-3.11
-    git_repository_guide_context:
     guide_name: codeready
     gogs_dev_user: developer
     gogs_pwd: openshift

--- a/apb/playbooks/tasks/create_project_logging_monitoring.yml
+++ b/apb/playbooks/tasks/create_project_logging_monitoring.yml
@@ -51,8 +51,8 @@
         -e CONTENT_URL_PREFIX={{ workshopper_content_url_prefix }}
         -n {{ infra_project_name }}
   vars:
-    workshopper_content_url_prefix: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}/{{ git_repository_guide_context }}"
-    workshopper_workshop_urls: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}/{{ git_repository_guide_context }}/_openshift-logging-monitoring.yml"
+    workshopper_content_url_prefix: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}"
+    workshopper_workshop_urls: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}/_openshift-logging-monitoring.yml"
   tags: guides
 - name: Expose Route
   command: >

--- a/apb/playbooks/tasks/create_project_service_mesh.yml
+++ b/apb/playbooks/tasks/create_project_service_mesh.yml
@@ -44,8 +44,8 @@
         -e CONTENT_URL_PREFIX={{ workshopper_content_url_prefix }}
         -n {{ infra_project_name }}
   vars:
-    workshopper_content_url_prefix: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}/{{ git_repository_guide_context }}"
-    workshopper_workshop_urls: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}/{{ git_repository_guide_context }}/_cloud-native-workshop-{{ guide_name }}.yml"
+    workshopper_content_url_prefix: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}"
+    workshopper_workshop_urls: "https://raw.githubusercontent.com/{{ git_repository_guide_path }}/{{ git_repository_guide_reference }}/_cloud-native-workshop-{{ guide_name }}.yml"
   tags: guides
 - name: Expose Route
   command: >


### PR DESCRIPTION
git_repository_guide_context was never defined and caused an issue with the WORKSHOPS_URLS parameter.